### PR TITLE
VS2013 support

### DIFF
--- a/src/AcklenAvenue.Email.Specs/AcklenAvenue.Email.Specs.csproj
+++ b/src/AcklenAvenue.Email.Specs/AcklenAvenue.Email.Specs.csproj
@@ -33,10 +33,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Machine.Specifications">
-      <HintPath>..\..\lib\Machine.Specifications.0.8.3\lib\net45\Machine.Specifications.dll</HintPath>
+      <HintPath>..\..\lib\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.Clr4">
-      <HintPath>..\..\lib\Machine.Specifications.0.8.3\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+      <HintPath>..\..\lib\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.Should">
       <HintPath>..\..\lib\Machine.Specifications.Should.0.7.2\lib\net45\Machine.Specifications.Should.dll</HintPath>

--- a/src/AcklenAvenue.Email.Specs/packages.config
+++ b/src/AcklenAvenue.Email.Specs/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Machine.Specifications" version="0.8.3" targetFramework="net45" />
+  <package id="Machine.Specifications" version="0.9.1" targetFramework="net45" />
   <package id="Machine.Specifications.Should" version="0.7.2" targetFramework="net45" />
   <package id="Moq" version="4.2.1409.1722" targetFramework="net45" />
 </packages>

--- a/src/Unicron.Data.Specs/Unicron.Data.Specs.csproj
+++ b/src/Unicron.Data.Specs/Unicron.Data.Specs.csproj
@@ -57,11 +57,11 @@
     </Reference>
     <Reference Include="Machine.Specifications, Version=0.8.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Machine.Specifications.0.8.3\lib\net45\Machine.Specifications.dll</HintPath>
+      <HintPath>..\..\lib\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.dll</HintPath>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4, Version=0.8.3.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Machine.Specifications.Clr4, Version=0.9.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Machine.Specifications.0.8.3\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+      <HintPath>..\..\lib\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.Should">
       <HintPath>..\..\lib\Machine.Specifications.Should.0.7.2\lib\net45\Machine.Specifications.Should.dll</HintPath>

--- a/src/Unicron.Data.Specs/packages.config
+++ b/src/Unicron.Data.Specs/packages.config
@@ -6,7 +6,7 @@
   <package id="EntityFramework" version="6.0.0" targetFramework="net45" />
   <package id="FluentNHibernate" version="1.4.0.0" targetFramework="net45" />
   <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net45" />
-  <package id="Machine.Specifications" version="0.8.3" targetFramework="net45" />
+  <package id="Machine.Specifications" version="0.9.1" targetFramework="net45" />
   <package id="Machine.Specifications.Should" version="0.7.2" targetFramework="net45" />
   <package id="NHibernate" version="3.3.1.4000" targetFramework="net45" />
   <package id="System.Data.SQLite" version="1.0.92.0" targetFramework="net45" />

--- a/src/Unicron.Domain.Specs/Unicron.Domain.Specs.csproj
+++ b/src/Unicron.Domain.Specs/Unicron.Domain.Specs.csproj
@@ -63,11 +63,11 @@
     </Reference>
     <Reference Include="Machine.Specifications, Version=0.8.3.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Machine.Specifications.0.8.3\lib\net45\Machine.Specifications.dll</HintPath>
+      <HintPath>..\..\lib\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.dll</HintPath>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4, Version=0.8.3.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Machine.Specifications.Clr4, Version=0.9.1.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\lib\Machine.Specifications.0.8.3\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+      <HintPath>..\..\lib\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.Should">
       <HintPath>..\..\lib\Machine.Specifications.Should.0.7.2\lib\net45\Machine.Specifications.Should.dll</HintPath>

--- a/src/Unicron.Domain.Specs/packages.config
+++ b/src/Unicron.Domain.Specs/packages.config
@@ -7,7 +7,7 @@
   <package id="BlingBag" version="1.3.3.0" targetFramework="net45" />
   <package id="ExpectedObjects" version="1.0.0.2" targetFramework="net45" />
   <package id="Iesi.Collections" version="3.2.0.4000" targetFramework="net45" />
-  <package id="Machine.Specifications" version="0.8.3" targetFramework="net45" />
+  <package id="Machine.Specifications" version="0.9.1" targetFramework="net45" />
   <package id="Machine.Specifications.Should" version="0.7.2" targetFramework="net45" />
   <package id="Moq" version="4.2.1409.1722" targetFramework="net45" />
   <package id="NBuilder" version="3.0.1.1" targetFramework="net45" />

--- a/src/Unicron.Web.Specs/Unicron.Web.Specs.csproj
+++ b/src/Unicron.Web.Specs/Unicron.Web.Specs.csproj
@@ -46,11 +46,13 @@
     <Reference Include="FizzWare.NBuilder">
       <HintPath>..\..\lib\NBuilder.3.0.1.1\lib\FizzWare.NBuilder.dll</HintPath>
     </Reference>
-    <Reference Include="Machine.Specifications">
-      <HintPath>..\..\lib\Machine.Specifications.0.8.3\lib\net45\Machine.Specifications.dll</HintPath>
+    <Reference Include="Machine.Specifications, Version=0.9.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.dll</HintPath>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4">
-      <HintPath>..\..\lib\Machine.Specifications.0.8.3\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+    <Reference Include="Machine.Specifications.Clr4, Version=0.9.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\lib\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
     </Reference>
     <Reference Include="Machine.Specifications.Should">
       <HintPath>..\..\lib\Machine.Specifications.Should.0.7.2\lib\net45\Machine.Specifications.Should.dll</HintPath>

--- a/src/Unicron.Web.Specs/packages.config
+++ b/src/Unicron.Web.Specs/packages.config
@@ -3,7 +3,7 @@
   <package id="AcklenAvenue.Testing.Moq.ExpectedObjects" version="1.0.1.3" targetFramework="net45" />
   <package id="BlingBag" version="1.3.1.1" targetFramework="net45" />
   <package id="ExpectedObjects" version="1.0.0.2" targetFramework="net45" />
-  <package id="Machine.Specifications" version="0.8.3" targetFramework="net45" />
+  <package id="Machine.Specifications" version="0.9.1" targetFramework="net45" />
   <package id="Machine.Specifications.Should" version="0.7.2" targetFramework="net45" />
   <package id="Moq" version="4.2.1409.1722" targetFramework="net45" />
   <package id="NBuilder" version="3.0.1.1" targetFramework="net45" />


### PR DESCRIPTION
Upgraded to MSpec 0.9.1 to get specs running over VS2013, Re# 8.2 & MSpec Runner 1.0.0